### PR TITLE
fix sprintf build error.

### DIFF
--- a/sound/soc/codecs/wcd_cpe_core.c
+++ b/sound/soc/codecs/wcd_cpe_core.c
@@ -1987,8 +1987,7 @@ struct wcd_cpe_core *wcd_cpe_init(const char *img_fname,
 	}
 
 	card = codec->component.card->snd_card;
-	snprintf(proc_name, (sizeof("cpe") + sizeof("_state") +
-		 sizeof(id) - 2), "%s%d%s", cpe_name, id, state_name);
+	snprintf(proc_name, sizeof(proc_name), "%s%d%s", cpe_name, id, state_name);
 	entry = snd_info_create_card_entry(card, proc_name,
 					   card->proc_root);
 	if (entry) {

--- a/sound/soc/codecs/wm_adsp.c
+++ b/sound/soc/codecs/wm_adsp.c
@@ -2051,7 +2051,7 @@ static void wm_adsp_change_device_name(const char *dev_num, char *name)
 			return;
 		}
 	}
-	strlcpy(name, dev_num, strlen(dev_num)+1);
+	memcpy(name, dev_num, strlen(dev_num)+1);
 }
 
 static int wm_adsp_load(struct wm_adsp *dsp)

--- a/sound/soc/codecs/wsa881x.c
+++ b/sound/soc/codecs/wsa881x.c
@@ -362,7 +362,7 @@ static ssize_t wsa881x_swrslave_reg_show(char __user *ubuf, size_t count,
 			continue;
 		swr_read(dbgwsa881x->swr_slave, devnum,
 			i, &reg_val, 1);
-		len = snprintf(tmp_buf, 25, "0x%.3x: 0x%.2x\n", i,
+		len = snprintf(tmp_buf, sizeof(tmp_buf), "0x%.3x: 0x%.2x\n", i,
 			       (reg_val & 0xFF));
 		if ((total + len) >= count - 1)
 			break;


### PR DESCRIPTION
This fixes a sprintf build error on lineage16.
A similar build error has been reported in [LineageOS / android_kernel_xiaomi_msm8953](https://github.com/LineageOS/android_kernel_xiaomi_msm8953) .

The target URLs of Lineage OS Gerrit are as follows.
  - [261276: ASoC: fix sprintf warning in wcd_cpe_core](https://review.lineageos.org/c/LineageOS/android_kernel_xiaomi_msm8953/+/261276)
  - [261275: ASoC: fix snprintf size arguments](https://review.lineageos.org/c/LineageOS/android_kernel_xiaomi_msm8953/+/261275)


I have confirmed that this commit does not cause problems building and launching evert(Moto G6 Plus).